### PR TITLE
[CASE-2] Avoid wrongfully calling view holder's previous checked chagned lisner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ captures/
 
 # IntelliJ
 *.iml
+/.idea/
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml

--- a/app/src/main/java/com/ravirawal/bheroassignment/beer_list_one/adapter/BeerListAdapter.kt
+++ b/app/src/main/java/com/ravirawal/bheroassignment/beer_list_one/adapter/BeerListAdapter.kt
@@ -34,6 +34,7 @@ class BeerListAdapter(private val onClick: (BeerUi, Int) -> Unit = { _, _ -> run
                     imageViewPrimaryTabOne.loadImage(it.imageUrl)
                     textViewTitleTabOne.text = it.name
 
+                    checkboxSelectedTabOne.setOnCheckedChangeListener{ _, _ ->{}}
                     checkboxSelectedTabOne.isChecked = it.isChecked ?: false
 
                     checkboxSelectedTabOne.setOnCheckedChangeListener { _, _ ->

--- a/app/src/main/java/com/ravirawal/bheroassignment/beer_list_one/ui/BeerListOneFragment.kt
+++ b/app/src/main/java/com/ravirawal/bheroassignment/beer_list_one/ui/BeerListOneFragment.kt
@@ -81,6 +81,7 @@ class BeerListOneFragment : Fragment(R.layout.fragment_recyclerview) {
                 beerListAdapter.submitData(pagedData)
             }
         }
+        beerListAdapter.notifyDataSetChanged()
     }
 
 }

--- a/app/src/main/java/com/ravirawal/bheroassignment/beer_list_two/adapter/BeerListAdapter.kt
+++ b/app/src/main/java/com/ravirawal/bheroassignment/beer_list_two/adapter/BeerListAdapter.kt
@@ -32,20 +32,19 @@ class BeerListAdapter(private val onClick: (BeerUi, Int) -> Unit = { _, _ -> run
                     imageViewPrimaryTabTwo.loadImage(it.imageUrl)
                     textViewTitleTabTwo.text = it.name
 
-                    checkboxSelectedTabTwo.isChecked = it.isChecked ?: false
+                    checkboxSelectedTabTwo.setOnCheckedChangeListener{ _, _ ->{}}
+                    checkboxSelectedTabTwo.isChecked = it.isChecked
 
-                    checkboxSelectedTabTwo.setOnCheckedChangeListener { _, b ->
-                        it.isChecked = !(it.isChecked ?: true)
+                    checkboxSelectedTabTwo.setOnCheckedChangeListener { _, isChecked ->
+                        it.isChecked = isChecked
                         onClick(it, checkboxSelectedTabTwo.id)
                     }
 
                     root.setOnClickListener { _ ->
                         onClick(it, root.id)
                     }
-
                 }
             }
         }
     }
 }
-

--- a/app/src/main/java/com/ravirawal/bheroassignment/beer_list_two/ui/BeerListTwoFragment.kt
+++ b/app/src/main/java/com/ravirawal/bheroassignment/beer_list_two/ui/BeerListTwoFragment.kt
@@ -68,6 +68,7 @@ class BeerListTwoFragment : Fragment(R.layout.fragment_recyclerview) {
                 beerListAdapter.submitData(pagedData)
             }
         }
+        beerListAdapter.notifyDataSetChanged()
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/ravirawal/bheroassignment/shared_vm/BeerListViewModel.kt
+++ b/app/src/main/java/com/ravirawal/bheroassignment/shared_vm/BeerListViewModel.kt
@@ -29,7 +29,7 @@ class BeerListViewModel(
         modificationEvents.value += Pair(beerUi.id ?: -1, beerUi.isChecked ?: false)
     }
 
-    private val modificationEvents = MutableStateFlow<Set<Pair<Int, Boolean>>>(emptySet())
+    private val modificationEvents = MutableStateFlow<Map<Int, Boolean>>(emptyMap())
 
     private val beerPagingData: Pager<Int, BeerUi> = Pager(pagingConfig) {
         BeerPagingSource(beerSources)
@@ -39,20 +39,19 @@ class BeerListViewModel(
         .flow
         .cachedIn(viewModelScope)
         .combine(modificationEvents) { pagingData, modifications ->
-            modifications.fold(pagingData) { acc, event ->
-                edit(acc, event)
-            }
+            edit(pagingData, modifications)
         }
 
     private fun edit(
         paging: PagingData<BeerUi>,
-        beerUi: Pair<Int, Boolean>
+        beerUi: Map<Int, Boolean>
     ): PagingData<BeerUi> {
         return paging
             .map {
-                if (beerUi.first == it.id) return@map it.copy(isChecked = beerUi.second)
-                else return@map it
+                if (beerUi.containsKey(it.id))
+                    return@map it.copy(isChecked = beerUi[it.id] == true)
+                else
+                    return@map it
             }
     }
-
 }

--- a/app/src/main/java/com/ravirawal/bheroassignment/shared_vm/BeerListViewModel.kt
+++ b/app/src/main/java/com/ravirawal/bheroassignment/shared_vm/BeerListViewModel.kt
@@ -26,7 +26,7 @@ class BeerListViewModel(
     )
 
     fun onNewEditRequest(beerUi: BeerUi) {
-        modificationEvents.value += Pair(beerUi.id ?: -1, beerUi.isChecked ?: false)
+        modificationEvents.value += Pair(beerUi.id ?: -1, beerUi.isChecked)
     }
 
     private val modificationEvents = MutableStateFlow<Map<Int, Boolean>>(emptyMap())


### PR DESCRIPTION
- By setting empty listenser, we can avoid calling view holder's previous checked changed listner